### PR TITLE
Move from failure to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["cfg", "rustc", "target", "parser"]
 license = "MIT OR Apache-2.0"
 name = "rustc-cfg"
 repository = "https://github.com/japaric/rustc-cfg"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
-failure = "0.1.3"
+thiserror = "1.0"


### PR DESCRIPTION
## Changes
- Moved from `failure` to `thiserror` for error handling
- Bumped version to 0.5.0 due to API breakage

## Description
As of `failure 0.1.8` [rust-lang-nursery/failure#347](https://github.com/rust-lang-nursery/failure/pull/347) it has been deprecated.

Additionally when interacting with this library you must either use `failure` or map the errors from `failure::Error` to `std::error::Error` via [failure::Error::compat()](https://docs.rs/failure/0.1.8/failure/struct.Error.html#method.compat). By instead using `thiserror` to provide a custom error type not only can we provide better information to callers but also means errors use `std::error::Error` and are easier to interact with.
