### PR TITLE
Remove 'failure' dep in favor of 'thiserror'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/japaric/rustc-cfg"
 version = "0.4.0"
 
 [dependencies]
-failure = "0.1.3"
+thiserror = "1"


### PR DESCRIPTION
The `failure` crate has been deprecated for some time, with a recommendation to use `thiserror` instead.  In addition, a critical memory safety issue (https://github.com/rust-lang-deprecated/failure/issues/336) has been found in `failure` that is unlikely to be fixed.  `rustc-cfg` is not vulnerable to the issue, but IMO it's better to just avoid having `failure` in our dependency trees at all.